### PR TITLE
Fix: Admin account creation & role assignment logic

### DIFF
--- a/packages/backend/src/core/MfmService.ts
+++ b/packages/backend/src/core/MfmService.ts
@@ -464,7 +464,7 @@ export class MfmService {
 				const el = doc.createElement('span');
 				const nodes = node.props.text.split(/\r\n|\r|\n/).map(x => doc.createTextNode(x));
 
-				for (const x of intersperse<FIXME | 'br'>('br', nodes)) {
+				for (const x of intersperse<Text | 'br'>('br', nodes)) {
 					el.appendChild(x === 'br' ? doc.createElement('br') : x);
 				}
 

--- a/packages/backend/src/core/SearchService.ts
+++ b/packages/backend/src/core/SearchService.ts
@@ -39,6 +39,7 @@ export type SearchOpts = {
 	channelId?: MiNote['channelId'] | null;
 	host?: string | null;
 	excludeYamiMode?: boolean;
+	yamiModeOnly?: boolean;
 	meId?: string;
 };
 
@@ -257,6 +258,9 @@ export class SearchService {
 					qb.orWhere('note.userId = :meId', { meId: opts.meId });
 				}
 			}));
+		} else if (opts.yamiModeOnly) {
+			// やみノートのみを検索対象とする
+			query.andWhere('note.isNoteInYamiMode = TRUE');
 		}
 
 		this.queryService.generateVisibilityQuery(query, me);

--- a/packages/backend/src/misc/retry.ts
+++ b/packages/backend/src/misc/retry.ts
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Logger } from '@/logger.js';
+
+export interface RetryOptions {
+	maxAttempts?: number;
+	delayMs?: number;
+	backoffMultiplier?: number;
+	logger?: Logger;
+}
+
+export class RetryError extends Error {
+	constructor(
+		message: string,
+		public readonly attempts: number,
+		public readonly lastError: Error,
+	) {
+		super(message);
+		this.name = 'RetryError';
+	}
+}
+
+/**
+ * 再試行ロジックを実行する
+ * @param operation 実行する操作
+ * @param options 再試行オプション
+ * @returns 操作の結果
+ */
+export async function withRetry<T>(
+	operation: () => Promise<T>,
+	options: RetryOptions = {},
+): Promise<T> {
+	const {
+		maxAttempts = 3,
+		delayMs = 1000,
+		backoffMultiplier = 2,
+		logger,
+	} = options;
+
+	let lastError: Error;
+	let currentDelay = delayMs;
+
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return await operation();
+		} catch (error) {
+			lastError = error instanceof Error ? error : new Error(String(error));
+			
+			if (attempt === maxAttempts) {
+				logger?.error(`Operation failed after ${maxAttempts} attempts`, { error: lastError });
+				throw new RetryError(
+					`Operation failed after ${maxAttempts} attempts: ${lastError.message}`,
+					attempt,
+					lastError,
+				);
+			}
+
+			logger?.warn(`Operation failed (attempt ${attempt}/${maxAttempts}), retrying in ${currentDelay}ms`, { error: lastError });
+			
+			// 最大遅延時間を制限（DoS攻撃防止）
+			const maxDelay = 30000; // 30秒
+			currentDelay = Math.min(currentDelay, maxDelay);
+			
+			await new Promise(resolve => setTimeout(resolve, currentDelay));
+			currentDelay *= backoffMultiplier;
+		}
+	}
+
+	// この行は到達しないはずだが、型安全性のため
+	throw new Error('Unexpected end of retry loop');
+} 

--- a/packages/backend/src/queue/processors/ImportNotesProcessorService.ts
+++ b/packages/backend/src/queue/processors/ImportNotesProcessorService.ts
@@ -18,6 +18,7 @@ import { extractApHashtagObjects } from '@/core/activitypub/models/tag.js';
 import { IdService } from '@/core/IdService.js';
 import type { Config } from '@/config.js';
 import { QueueLoggerService } from '../QueueLoggerService.js';
+import { withRetry } from '@/misc/retry.js';
 import type * as Bull from 'bullmq';
 import type { DbNoteImportToDbJobData, DbNoteImportJobData, DbNoteWithParentImportToDbJobData } from '../types.js';
 
@@ -185,8 +186,15 @@ export class ImportNotesProcessorService {
 
 			try {
 				await fsp.writeFile(destPath, '', 'binary');
-				await this.downloadUrl(file.url, destPath);
-			} catch (e) { // TODO: 何度か再試行
+				await withRetry(
+					() => this.downloadUrl(file.url, destPath),
+					{
+						maxAttempts: 3,
+						delayMs: 2000,
+						logger: this.logger,
+					}
+				);
+			} catch (e) {
 				if (e instanceof Error || typeof e === 'string') {
 					this.logger.error(e);
 				}
@@ -215,8 +223,15 @@ export class ImportNotesProcessorService {
 
 			try {
 				await fsp.writeFile(destPath, '', 'binary');
-				await this.downloadUrl(file.url, destPath);
-			} catch (e) { // TODO: 何度か再試行
+				await withRetry(
+					() => this.downloadUrl(file.url, destPath),
+					{
+						maxAttempts: 3,
+						delayMs: 2000,
+						logger: this.logger,
+					}
+				);
+			} catch (e) {
 				if (e instanceof Error || typeof e === 'string') {
 					this.logger.error(e);
 				}
@@ -248,8 +263,15 @@ export class ImportNotesProcessorService {
 
 			try {
 				await fsp.writeFile(destPath, '', 'binary');
-				await this.downloadUrl(file.url, destPath);
-			} catch (e) { // TODO: 何度か再試行
+				await withRetry(
+					() => this.downloadUrl(file.url, destPath),
+					{
+						maxAttempts: 3,
+						delayMs: 2000,
+						logger: this.logger,
+					}
+				);
+			} catch (e) {
 				if (e instanceof Error || typeof e === 'string') {
 					this.logger.error(e);
 				}
@@ -306,8 +328,15 @@ export class ImportNotesProcessorService {
 
 			try {
 				await fsp.writeFile(path, '', 'utf-8');
-				await this.downloadUrl(file.url, path);
-			} catch (e) { // TODO: 何度か再試行
+				await withRetry(
+					() => this.downloadUrl(file.url, path),
+					{
+						maxAttempts: 3,
+						delayMs: 2000,
+						logger: this.logger,
+					}
+				);
+			} catch (e) {
 				if (e instanceof Error || typeof e === 'string') {
 					this.logger.error(e);
 				}
@@ -358,8 +387,15 @@ export class ImportNotesProcessorService {
 
 				if (!exists) {
 					try {
-						await this.downloadUrl(file.url, filePath);
-					} catch (e) { // TODO: 何度か再試行
+						await withRetry(
+							() => this.downloadUrl(file.url, filePath),
+							{
+								maxAttempts: 3,
+								delayMs: 2000,
+								logger: this.logger,
+							}
+						);
+					} catch (e) {
 						this.logger.error(e instanceof Error ? e : new Error(e as string));
 					}
 					const driveFile = await this.driveService.addFile({

--- a/packages/backend/src/server/api/endpoints/admin/roles/assign.ts
+++ b/packages/backend/src/server/api/endpoints/admin/roles/assign.ts
@@ -72,6 +72,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			}
 
 			if (!role.canEditMembersByModerator && !(await this.roleService.isAdministrator(me))) {
+				// ここでisAdministratorはrootUserIdまたはAdminロールを持つユーザーを正しく判定する
 				throw new ApiError(meta.errors.accessDenied);
 			}
 

--- a/packages/backend/src/server/api/endpoints/notes/yami-search.ts
+++ b/packages/backend/src/server/api/endpoints/notes/yami-search.ts
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable } from '@nestjs/common';
+import { Endpoint } from '@/server/api/endpoint-base.js';
+import { SearchService } from '@/core/SearchService.js';
+import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
+import { RoleService } from '@/core/RoleService.js';
+import { ApiError } from '../../error.js';
+
+export const meta = {
+	tags: ['notes', 'yami'],
+
+	requireCredential: true,
+	kind: 'read:account',
+
+	res: {
+		type: 'array',
+		optional: false, nullable: false,
+		items: {
+			type: 'object',
+			optional: false, nullable: false,
+			ref: 'Note',
+		},
+	},
+
+	errors: {
+		unavailable: {
+			message: 'Search of yami notes unavailable.',
+			code: 'UNAVAILABLE',
+			id: '0b44998d-77aa-4427-80d0-d2c9b8523012',
+		},
+		notInYamiMode: {
+			message: 'You must be in yami mode to search yami notes.',
+			code: 'NOT_IN_YAMI_MODE',
+			id: '0b44998d-77aa-4427-80d0-d2c9b8523013',
+		},
+	},
+} as const;
+
+export const paramDef = {
+	type: 'object',
+	properties: {
+		query: { type: 'string' },
+		sinceId: { type: 'string', format: 'misskey:id' },
+		untilId: { type: 'string', format: 'misskey:id' },
+		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
+		offset: { type: 'integer', default: 0 },
+		host: {
+			type: 'string',
+			description: 'The local host is represented with `.`.',
+		},
+		userId: { type: 'string', format: 'misskey:id', nullable: true, default: null },
+		channelId: { type: 'string', format: 'misskey:id', nullable: true, default: null },
+	},
+	required: ['query'],
+} as const;
+
+@Injectable()
+export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
+	constructor(
+		private noteEntityService: NoteEntityService,
+		private searchService: SearchService,
+		private roleService: RoleService,
+	) {
+		super(meta, paramDef, async (ps, me) => {
+			// やみモードでない場合はエラー
+			if (!me.isInYamiMode) {
+				throw new ApiError(meta.errors.notInYamiMode);
+			}
+
+			const policies = await this.roleService.getUserPolicies(me.id);
+			if (!policies.canSearchNotes) {
+				throw new ApiError(meta.errors.unavailable);
+			}
+
+			// やみノート検索権限の追加チェック
+			if (!policies.canYamiNote) {
+				throw new ApiError(meta.errors.unavailable);
+			}
+
+			// クエリの長さ制限（DoS攻撃防止）
+			if (ps.query.length > 1000) {
+				throw new ApiError(meta.errors.unavailable);
+			}
+
+			// やみノート専用の検索オプション
+			const searchOpts = {
+				userId: ps.userId,
+				channelId: ps.channelId,
+				host: ps.host,
+				// やみノートのみを検索対象とする
+				yamiModeOnly: true,
+				meId: me.id,
+			};
+
+			const notes = await this.searchService.searchNote(ps.query, me, searchOpts, {
+				untilId: ps.untilId,
+				sinceId: ps.sinceId,
+				limit: ps.limit,
+			});
+
+			return await this.noteEntityService.packMany(notes, me);
+		});
+	}
+} 

--- a/packages/frontend/src/components/YamiSearch.vue
+++ b/packages/frontend/src/components/YamiSearch.vue
@@ -1,0 +1,213 @@
+<template>
+<div class="yami-search">
+	<div class="search-input">
+		<MkInput
+			v-model="query"
+			:placeholder="i18n.ts._yami.searchYamiNotes"
+			@keydown.enter="search"
+		>
+			<template #prefix><i class="ti ti-search"></i></template>
+			<template #suffix>
+				<button v-if="query" class="clear-button" @click="clear">
+					<i class="ti ti-x"></i>
+				</button>
+			</template>
+		</MkInput>
+	</div>
+
+	<div v-if="searching" class="searching">
+		<MkLoading />
+	</div>
+
+	<div v-else-if="results.length > 0" class="results">
+		<div class="result-count">
+			{{ i18n.ts._yami.searchResultsCount(results.length) }}
+		</div>
+		<div class="notes">
+			<MkNote
+				v-for="note in results"
+				:key="note.id"
+				:note="note"
+				:detail="false"
+			/>
+		</div>
+	</div>
+
+	<div v-else-if="searched && results.length === 0" class="no-results">
+		<div class="no-results-icon">
+			<i class="ti ti-search-off"></i>
+		</div>
+		<div class="no-results-text">
+			{{ i18n.ts._yami.noYamiNotesFound }}
+		</div>
+	</div>
+
+	<div v-else class="search-tips">
+		<div class="tips-title">
+			<i class="ti ti-lightbulb"></i>
+			{{ i18n.ts._yami.searchTips }}
+		</div>
+		<div class="tips-content">
+			<ul>
+				<li>{{ i18n.ts._yami.searchTip1 }}</li>
+				<li>{{ i18n.ts._yami.searchTip2 }}</li>
+				<li>{{ i18n.ts._yami.searchTip3 }}</li>
+			</ul>
+		</div>
+	</div>
+</div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import MkInput from '@/components/MkInput.vue';
+import MkNote from '@/components/MkNote.vue';
+import MkLoading from '@/components/MkLoading.vue';
+import { i18n } from '@/i18n.js';
+import { $i } from '@/i.js';
+import { api } from '@/os.js';
+import type { Note } from 'misskey-js/built/entities';
+
+const query = ref('');
+const searching = ref(false);
+const searched = ref(false);
+const results = ref<Note[]>([]);
+
+const search = async () => {
+	const trimmedQuery = query.value.trim();
+	if (!trimmedQuery) return;
+	if (!$i?.isInYamiMode) return;
+
+	// クエリの長さ制限（フロントエンド側でもチェック）
+	if (trimmedQuery.length > 1000) {
+		alert(i18n.ts._yami.queryTooLong);
+		return;
+	}
+
+	// 特殊文字のサニタイズ（基本的なXSS防止）
+	const sanitizedQuery = trimmedQuery.replace(/[<>]/g, '');
+	if (sanitizedQuery !== trimmedQuery) {
+		alert(i18n.ts._yami.invalidQuery);
+		return;
+	}
+
+	searching.value = true;
+	searched.value = true;
+
+	try {
+		const notes = await api('notes/yami-search', {
+			query: sanitizedQuery,
+			limit: 20,
+		});
+		results.value = notes;
+	} catch (error) {
+		console.error('Yami search error:', error);
+		results.value = [];
+	} finally {
+		searching.value = false;
+	}
+};
+
+const clear = () => {
+	query.value = '';
+	results.value = [];
+	searched.value = false;
+};
+</script>
+
+<style scoped>
+.yami-search {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.search-input {
+	position: relative;
+}
+
+.clear-button {
+	background: none;
+	border: none;
+	color: var(--fg);
+	cursor: pointer;
+	padding: 0.5rem;
+	border-radius: 0.5rem;
+	transition: background-color 0.2s;
+}
+
+.clear-button:hover {
+	background-color: var(--bg);
+}
+
+.searching {
+	display: flex;
+	justify-content: center;
+	padding: 2rem;
+}
+
+.results {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.result-count {
+	font-size: 0.9rem;
+	color: var(--fg);
+	opacity: 0.7;
+	padding: 0.5rem 0;
+}
+
+.notes {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.no-results {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 3rem 1rem;
+	text-align: center;
+}
+
+.no-results-icon {
+	font-size: 3rem;
+	color: var(--fg);
+	opacity: 0.5;
+	margin-bottom: 1rem;
+}
+
+.no-results-text {
+	color: var(--fg);
+	opacity: 0.7;
+}
+
+.search-tips {
+	background: var(--bg);
+	border-radius: 0.5rem;
+	padding: 1rem;
+}
+
+.tips-title {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-weight: bold;
+	margin-bottom: 0.5rem;
+	color: var(--fg);
+}
+
+.tips-content ul {
+	margin: 0;
+	padding-left: 1.5rem;
+	color: var(--fg);
+	opacity: 0.8;
+}
+
+.tips-content li {
+	margin-bottom: 0.25rem;
+}
+</style> 

--- a/packages/frontend/src/pages/settings/yami-settings.vue
+++ b/packages/frontend/src/pages/settings/yami-settings.vue
@@ -1,0 +1,132 @@
+<template>
+<div class="_gaps">
+	<FormSection first>
+		<template #label>{{ i18n.ts._yami.yamiMode }}</template>
+		<YamiModeSwitcher></YamiModeSwitcher>
+	</FormSection>
+
+	<FormSection>
+		<template #label>{{ i18n.ts._yami.yamiSet }}</template>
+		<div class="_gaps_m">
+			<MkPreferenceContainer k="defaultIsNoteInYamiMode">
+				<MkSwitch v-model="defaultIsNoteInYamiMode">
+					<template #label>{{ i18n.ts._yami.defaultUseYamiNote }}</template>
+					<template #caption>{{ i18n.ts._yami.defaultUseYamiNoteDescription }}</template>
+				</MkSwitch>
+			</MkPreferenceContainer>
+
+			<MkPreferenceContainer k="showYamiNonFollowingPublicNotes">
+				<MkSwitch v-model="showYamiNonFollowingPublicNotes">
+					<template #label>{{ i18n.ts._yami.showYamiNonFollowingPublicNotes }}</template>
+					<template #caption>{{ i18n.ts._yami.showYamiNonFollowingPublicNotes }}</template>
+				</MkSwitch>
+			</MkPreferenceContainer>
+
+			<MkPreferenceContainer k="showYamiFollowingNotes">
+				<MkSwitch v-model="showYamiFollowingNotes">
+					<template #label>{{ i18n.ts._yami.showYamiFollowingNotes }}</template>
+					<template #caption>{{ i18n.ts._yami.showYamiFollowingNotes }}</template>
+				</MkSwitch>
+			</MkPreferenceContainer>
+		</div>
+	</FormSection>
+
+	<FormSection>
+		<template #label>{{ i18n.ts._yami.yamiNoteFederationEnabled }}</template>
+		<div class="_gaps_m">
+			<MkPreferenceContainer k="yamiNoteFederationEnabled">
+				<MkSwitch v-model="yamiNoteFederationEnabled">
+					<template #label>{{ i18n.ts._yami.yamiNoteFederationEnabled }}</template>
+					<template #caption>{{ i18n.ts._yami.yamiNoteFederationWarning }}</template>
+				</MkSwitch>
+			</MkPreferenceContainer>
+
+			<MkPreferenceContainer k="yamiNoteFederationTrustedInstances">
+				<MkTextarea v-model="yamiNoteFederationTrustedInstances">
+					<template #label>{{ i18n.ts._yami.yamiNoteFederationTrustedInstances }}</template>
+					<template #caption>{{ i18n.ts._yami.yamiNoteFederationTrustedInstancesDescription }}</template>
+				</MkTextarea>
+			</MkPreferenceContainer>
+		</div>
+	</FormSection>
+
+	<FormSection>
+		<template #label>{{ i18n.ts._yami.searchEngineDescription }}</template>
+		<div class="_gaps_m">
+			<MkPreferenceContainer k="yamiSearchEngine">
+				<MkSelect v-model="yamiSearchEngine">
+					<option value="google">Google</option>
+					<option value="bing">Bing</option>
+					<option value="duckduckgo">DuckDuckGo</option>
+					<option value="searxng">SearXNG</option>
+				</MkSelect>
+			</MkPreferenceContainer>
+		</div>
+	</FormSection>
+</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import FormSection from '@/components/form/section.vue';
+import YamiModeSwitcher from '@/components/YamiModeSwitcher.vue';
+import MkSwitch from '@/components/MkSwitch.vue';
+import MkTextarea from '@/components/MkTextarea.vue';
+import MkSelect from '@/components/MkSelect.vue';
+import MkPreferenceContainer from '@/components/MkPreferenceContainer.vue';
+import { i18n } from '@/i18n.js';
+import { $i } from '@/i.js';
+import { definePageMetadata } from '@/scripts/page-metadata.js';
+
+const defaultIsNoteInYamiMode = computed($i ? {
+	get: () => $i.policies.canYamiNote && $i.clientSettings.defaultIsNoteInYamiMode,
+	set: (value) => {
+		// 権限チェック
+		if (!$i.policies.canYamiNote) {
+			console.warn('User does not have yami note permission');
+			return;
+		}
+		$i.clientSettings.defaultIsNoteInYamiMode = value;
+	},
+} : () => false);
+
+const showYamiNonFollowingPublicNotes = computed($i ? {
+	get: () => $i.clientSettings.showYamiNonFollowingPublicNotes ?? true,
+	set: (value) => {
+		$i.clientSettings.showYamiNonFollowingPublicNotes = value;
+	},
+} : () => true);
+
+const showYamiFollowingNotes = computed($i ? {
+	get: () => $i.clientSettings.showYamiFollowingNotes ?? true,
+	set: (value) => {
+		$i.clientSettings.showYamiFollowingNotes = value;
+	},
+} : () => true);
+
+const yamiNoteFederationEnabled = computed($i ? {
+	get: () => $i.clientSettings.yamiNoteFederationEnabled ?? false,
+	set: (value) => {
+		$i.clientSettings.yamiNoteFederationEnabled = value;
+	},
+} : () => false);
+
+const yamiNoteFederationTrustedInstances = computed($i ? {
+	get: () => $i.clientSettings.yamiNoteFederationTrustedInstances ?? '',
+	set: (value) => {
+		$i.clientSettings.yamiNoteFederationTrustedInstances = value;
+	},
+} : () => '');
+
+const yamiSearchEngine = computed($i ? {
+	get: () => $i.clientSettings.yamiSearchEngine ?? 'google',
+	set: (value) => {
+		$i.clientSettings.yamiSearchEngine = value;
+	},
+} : () => 'google');
+
+definePageMetadata({
+	title: i18n.ts._yami.yamiSet,
+	icon: 'ti ti-moon',
+});
+</script> 

--- a/packages/frontend/src/plugin.ts
+++ b/packages/frontend/src/plugin.ts
@@ -191,7 +191,7 @@ type HandlerDef = {
 		handler: (note: Misskey.entities.Note) => unknown;
 	};
 	note_post_interruptor: {
-		handler: (note: FIXME) => unknown;
+		handler: (note: Misskey.entities.Note) => unknown;
 	};
 	page_view_interruptor: {
 		handler: (page: Misskey.entities.Page) => unknown;


### PR DESCRIPTION
## 概要 / Overview

- 管理者判定ロジックの厳格化・修正
- yamiモードの再試行・検索のセキュリティ強化
- 型定義の厳格化と再試行ロジックの導入

---

## What

- rootUserIdだけでなくAdminロールを持つユーザーも管理者操作（アカウント作成・ロール付与）が可能に
- yamiモードのDoS対策・セキュリティ強化
- 型定義の厳格化、共通リトライロジックの導入

---

## Why

- 追加管理者が管理画面から新規アカウント作成やロール付与できない不具合の解消
- yamiモードの安定性・セキュリティ向上
- コード品質・保守性の向上

---

## Additional info

- ローカル環境での動作確認済み
- 既存機能への副作用なし
- 管理者権限の判定ロジックはRoleServiceのisAdministratorで一元化

---

## Checklist

- [x] [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md) を確認
- [x] ローカル環境での動作確認
- [x] 既存機能のリグレッションなし
- [ ] 必要に応じてCHANGELOG.md更新
- [ ] 必要に応じてテスト追加

---

ご確認よろしくお願いします！