### PR TITLE
feat(types): Add isNoteInYamiMode property to Note and CreateNoteSchema

### DIFF
--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -10279,6 +10279,7 @@ export type components = {
             localOnly?: boolean;
             /** @enum {string|null} */
             reactionAcceptance: 'likeOnly' | 'likeOnlyForRemote' | 'nonSensitiveOnly' | 'nonSensitiveOnlyForLocalLikeOnlyForRemote' | null;
+            isNoteInYamiMode?: boolean;
         };
         NoteReaction: {
             /**
@@ -37288,6 +37289,8 @@ export interface operations {
                     renoteId?: string | null;
                     /** Format: misskey:id */
                     channelId?: string | null;
+                    /** @default false */
+                    isNoteInYamiMode?: boolean;
                     text?: string | null;
                     fileIds?: string[];
                     poll?: {
@@ -37548,6 +37551,8 @@ export interface operations {
                     renoteId?: string | null;
                     /** Format: misskey:id */
                     channelId?: string | null;
+                    /** @default false */
+                    isNoteInYamiMode?: boolean;
                     text?: string | null;
                     fileIds?: string[];
                     poll?: {


### PR DESCRIPTION
## What
自動生成された型定義に、yamisskey 独自の「Yami Mode」機能に対応する isNoteInYamiMode プロパティを追加しました。これにより、ノート作成および表示時に「Yami Mode」の状態をAPIで扱えるようになります。

## Why
「Yami Mode」機能の導入に伴い、ノートが「Yami Mode」であるかどうかをAPIレベルで判別できるようにするためです。これにより、クライアントや他のサービスがこの状態を正確に認識し、適切に処理できるようになります。

## Additional info (optional)
自動生成ファイル（types.ts）のみの変更であり、既存機能への影響はありません。